### PR TITLE
apfs: fix apfs_table_is_* functions

### DIFF
--- a/fs/apfs/table.h
+++ b/fs/apfs/table.h
@@ -128,26 +128,31 @@ struct apfs_table {
 };
 
 /**
- * apfs_table_is_leaf - Check if a b-tree table is a leaf
+ * apfs_table_is_leaf - Check if a b-tree table is a leaf node
  * @table: the table to check
- *
- * This function would probably not be necessary if I just gave a name to the
- * magical constant 2 that it uses, but I'm not sure of its meaning.
  */
 static inline bool apfs_table_is_leaf(struct apfs_table *table)
 {
-	return (table->t_flags & 2) != 0;
+	return (table->t_flags & APFS_BTNODE_LEAF) != 0;
 }
 
 /**
- * apfs_table_is_omap - Check if a b-tree table belongs to the omap
+ * apfs_table_is_root - Check if a b-tree table is a root node
  * @table: the table to check
- *
- * This function is no longer used, but I'm keeping it as documentation for now.
  */
-static inline bool apfs_table_is_omap(struct apfs_table *table)
+static inline bool apfs_table_is_root(struct apfs_table *table)
 {
-	return (table->t_flags & 4) != 0;
+	return (table->t_flags & APFS_BTNODE_ROOT) != 0;
+}
+
+/**
+ * apfs_table_has_fixed_kv_size - Check if a b-tree table has fixed key/value
+ * sizes
+ * @table: the table to check
+ */
+static inline bool apfs_table_has_fixed_kv_size(struct apfs_table *table)
+{
+	return (table->t_flags & APFS_BTNODE_FIXED_KV_SIZE) != 0;
 }
 
 extern struct apfs_table *apfs_read_table(struct super_block *sb, u64 block);


### PR DESCRIPTION
This patch makes apfs_table_is_leaf() and apfs_table_is_omap() use
macros instead of numeric constants, and adds an apfs_table_is_root()
function (some tables may have both flags set, so we need to be able to
test them separately).

Moreover, apfs_table_is_omap() is renamed to
apfs_table_has_fixed_kv_size() as the previous name was misleading (a
node with fixed key/value sizes is not always an object map).

Signed-off-by: Arnaud Ferraris <arnaud.ferraris@collabora.com>
Signed-off-by: Ernesto A. Fernández <ernesto.mnd.fernandez@gmail.com>