### PR TITLE
apfs: cache latest extent record

### DIFF
--- a/fs/apfs/apfs.h
+++ b/fs/apfs/apfs.h
@@ -109,6 +109,15 @@ struct apfs_file_extent_val {
 } __packed;
 
 /*
+ * Extent record data in memory
+ */
+struct apfs_file_extent {
+	u64 logical_addr;
+	u64 phys_block_num;
+	u64 len;
+};
+
+/*
  * Inode and file operations
  */
 

--- a/fs/apfs/inode.h
+++ b/fs/apfs/inode.h
@@ -106,7 +106,9 @@ struct apfs_dstream {
  * APFS inode data in memory
  */
 struct apfs_inode_info {
-	struct timespec i_crtime;	/* Time of creation */
+	struct apfs_file_extent	i_cached_extent; /* Latest extent record */
+	struct mutex		i_extent_lock;	 /* Protects i_cached_extent */
+	struct timespec		i_crtime;	 /* Time of creation */
 
 	struct inode vfs_inode;
 };

--- a/fs/apfs/super.c
+++ b/fs/apfs/super.c
@@ -100,6 +100,8 @@ static void init_once(void *p)
 {
 	struct apfs_inode_info *ai = (struct apfs_inode_info *)p;
 
+	mutex_init(&ai->i_extent_lock);
+	ai->i_cached_extent.len = 0;
 	inode_init_once(&ai->vfs_inode);
 }
 


### PR DESCRIPTION
Keep a cache of the last extent record used in apfs_inode_info, to avoid
repeated queries on sequential reads.

Signed-off-by: Ernesto A. Fernández <ernesto.mnd.fernandez@gmail.com>
Reviewed-by: Arnaud Ferraris <arnaud.ferraris@collabora.com>